### PR TITLE
Add qblog export mode to rss plugin

### DIFF
--- a/plugin/rss.inc.php
+++ b/plugin/rss.inc.php
@@ -175,6 +175,10 @@ function plugin_rss_action()
 		case '0.91': /* FALLTHROUGH */
 		case '2.0':
 			$wp_post_type = $page_export ? '<wp:post_type>page</wp:post_type>' : '';
+			$wp_post_type = $qblog_export ? '<wp:post_type>post</wp:post_type>' : $wp_post_type;
+
+			$permalink = "{$self}?{$r_page}";
+			$wp_qhm_permalink = $qblog_export || $page_export ? '<wp:postmeta><wp:meta_key>qhm_permalink</wp:meta_key><wp:meta_value>'.$permalink.'</wp:meta_value></wp:postmeta>' : '';
 			$date = get_date('D, d M Y H:i:s T', $time);
 			if ($version == '0.91') {
 				$date = '';
@@ -190,10 +194,11 @@ function plugin_rss_action()
 			$items .= <<<EOD
 <item>
  <title>$title</title>
- <link>$self?$r_page</link>
+ <link>$permalink</link>
 $date
 $desc
 $wp_post_type
+$wp_qhm_permalink
 </item>
 
 EOD;
@@ -238,7 +243,7 @@ EOD;
 	$page_title_utf8 = h(plugin_rss_utf8_for_xml($page_title_utf8));
 	$description = h(plugin_rss_utf8_for_xml($description));
 
-	$wxr_definitions = $page_export ? '
+	$wxr_definitions = $page_export || $qblog_export ? '
   <wp:wxr_version>1.2</wp:wxr_version>
 ' : '';
 

--- a/plugin/rss.inc.php
+++ b/plugin/rss.inc.php
@@ -379,7 +379,7 @@ function plugin_rss_get_wp_comments($page)
 			continue;
 		}
 
-		$comment_body = $comment['msg'];
+		$comment_body = h($comment['msg']);
 		$comment_body = nl2br($comment_body);
 		$ptns = array(
 			'/(?:https?|ftp)(?::\/\/[-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#]+)/',
@@ -388,6 +388,7 @@ function plugin_rss_get_wp_comments($page)
 			'<a href="$0">$0</a>'
 		);
 		$comment_body = preg_replace($ptns, $rpls, $comment_body);
+		$comment_body = '<b>' . h($comment['title']) . "</b><br>\n<br>\n" .$comment_body;
 
 		// datetime: 2016.09.15 13:22:43
 		//var_dump($comment);

--- a/plugin/rss.inc.php
+++ b/plugin/rss.inc.php
@@ -400,8 +400,8 @@ function plugin_rss_get_wp_comments($page)
 			(int)substr($comment['datetime'], 8, 2),
 			(int)substr($comment['datetime'], 0, 4)
 		);
-		$date   = date('D, d M Y H:i:s T', $time);
-		$gmdate = gmdate('D, d M Y H:i:s T', $time);
+		$date   = date('Y-m-d H:i:s', $time);
+		$gmdate = gmdate('Y-m-d H:i:s', $time);
 
 		$xml .= "<wp:comment>\n";
 

--- a/plugin/rss.inc.php
+++ b/plugin/rss.inc.php
@@ -177,6 +177,10 @@ function plugin_rss_action()
 			$wp_post_type = $page_export ? '<wp:post_type>page</wp:post_type>' : '';
 			$wp_post_type = $qblog_export ? '<wp:post_type>post</wp:post_type>' : $wp_post_type;
 
+			$post_date = date('Y-m-d H:i:s', $time);
+			$post_date_gmt = gmdate('Y-m-d H:i:s', $time);
+			$wp_post_date = $page_export || $qblog_export ? '<wp:post_date>'.$post_date.'</wp:post_date><wp:post_date_gmt>'.$post_date_gmt.'</wp:post_date_gmt>' : '';
+
 			$permalink = "{$self}?{$r_page}";
 			$wp_qhm_permalink = $qblog_export || $page_export ? '<wp:postmeta><wp:meta_key>qhm_permalink</wp:meta_key><wp:meta_value>'.$permalink.'</wp:meta_value></wp:postmeta>' : '';
 			$date = get_date('D, d M Y H:i:s T', $time);
@@ -198,6 +202,7 @@ function plugin_rss_action()
 $date
 $desc
 $wp_post_type
+$wp_post_date
 $wp_qhm_permalink
 </item>
 


### PR DESCRIPTION
## 概要
- RSS プラグインにブログ・ページのエクスポート機能を追加
- ブログ・ページの全記事のHTMLを RSS 2.0 拡張の WXR 形式で出力する
- ブログ・ページともにWPに読み込むとドラフトとなる
- ブログはカテゴリ `<category>` とコメント `<wp:comment>` も出力する
- 301転送処理のため、 `qhm_permalink` というカスタムフィールドを持たせる
- `wp:post_date` を出力するため、QHMの公開日時をそのまま引き継げる
## 使い方

`http://example.com/index.php?cmd=rss&qblog_rss=1&qblog_export={username}`

`http://example.com/index.php?cmd=rss&page_export={username}`

へアクセスする。
`{username}` は各QHMで設定している管理者ユーザー名に置換すること。
## 注意点

QHMが出力する画像のパスは相対パスのため、
インポート先で読み込めない恐れがあるのでURLに変換する処理を追加済み。

``` html
<!-- 置換の例 -->
<img src="swfu/d/hoge.jpg" ... />
が
<img src="http://example.com/swfu/d/hoge.jpg" ... />
のように置換されます。
```

簡単のため swfu フォルダ以外の画像は無視した。
